### PR TITLE
update to license key secret name

### DIFF
--- a/yaml/frontend.yaml
+++ b/yaml/frontend.yaml
@@ -48,8 +48,8 @@ spec:
         - name: NEW_RELIC_LICENSE_KEY
           valueFrom:
             secretKeyRef:
-              name: newrelic-bundle-newrelic-infrastructure-config
-              key: license
+              name: newrelic-secret
+              key: new_relic_license_key
         - name: NEW_RELIC_APP_NAME
           value: K8s guestbook - frontend
           # tells the node.js app to pause at random intervals

--- a/yaml/parser.yaml
+++ b/yaml/parser.yaml
@@ -49,8 +49,8 @@ spec:
         - name: NEW_RELIC_LICENSE_KEY
           valueFrom:
             secretKeyRef:
-              name: newrelic-bundle-newrelic-infrastructure-config
-              key: license
+              name: newrelic-secret
+              key: new_relic_license_key
         - name: NEW_RELIC_APP_NAME
           value: K8s guestbook - parser
           # tells the node.js app to pause at random intervals

--- a/yaml/worker.yaml
+++ b/yaml/worker.yaml
@@ -46,8 +46,8 @@ spec:
         - name: NEW_RELIC_LICENSE_KEY
           valueFrom:
             secretKeyRef:
-              name: newrelic-bundle-newrelic-infrastructure-config
-              key: license
+              name: newrelic-secret
+              key: new_relic_license_key
         - name: NEW_RELIC_APP_NAME
           value: K8s guestbook - worker
         - name: GET_HOSTS_FROM


### PR DESCRIPTION
updating the license key secret name to align with what is setup in [README.md](https://github.com/newrelic-experimental/kubernetes-demo-apps/blob/main/README.md). The NR Helm charts no longer create the secret formerly referenced and this work-around has been tested and verified. 